### PR TITLE
feat: metadate for tracing integrations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # NOTE: once we add more dependencies, consider update dependabot to check for updates
 
-lightning-sdk >=0.2.7
+lightning-sdk >=0.2.9
 lightning-utilities
 joblib

--- a/src/litmodels/integrations/duplicate.py
+++ b/src/litmodels/integrations/duplicate.py
@@ -4,11 +4,22 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
+from lightning_utilities import module_available
+
 from litmodels import upload_model
+
+if module_available("huggingface_hub"):
+    from huggingface_hub import snapshot_download
+else:
+    snapshot_download = None
 
 
 def duplicate_hf_model(
-    hf_model: str, lit_model: Optional[str] = None, local_workdir: Optional[str] = None, verbose: int = 1
+    hf_model: str,
+    lit_model: Optional[str] = None,
+    local_workdir: Optional[str] = None,
+    verbose: int = 1,
+    metadata: Optional[dict] = None,
 ) -> str:
     """Downloads the model from Hugging Face and uploads it to Lightning Cloud.
 
@@ -18,13 +29,12 @@ def duplicate_hf_model(
         local_workdir:
             The local working directory to use for the duplication process. If not set a temp folder will be created.
         verbose: Shot a progress bar for the upload.
+        metadata: Optional metadata to attach to the model. If not provided, a default metadata will be used.
 
     Returns:
         The name of the duplicated model in Lightning Cloud.
     """
-    try:
-        from huggingface_hub import snapshot_download
-    except ModuleNotFoundError:
+    if not snapshot_download:
         raise ModuleNotFoundError(
             "Hugging Face Hub is not installed. Please install it with `pip install huggingface_hub`."
         )
@@ -52,5 +62,8 @@ def duplicate_hf_model(
     # Upload the model to Lightning Cloud
     if not lit_model:
         lit_model = model_name
-    model = upload_model(name=lit_model, model=local_workdir / model_name, verbose=verbose)
+    if not metadata:
+        metadata = {}
+    metadata.update({"litModels_integration": "duplicate_hf_model", "hf_model": hf_model})
+    model = upload_model(name=lit_model, model=local_workdir / model_name, verbose=verbose, metadata=metadata)
     return model.name

--- a/src/litmodels/io/cloud.py
+++ b/src/litmodels/io/cloud.py
@@ -10,6 +10,8 @@ from lightning_sdk.models import _extend_model_name_with_teamspace, _parse_model
 from lightning_sdk.models import download_model as sdk_download_model
 from lightning_sdk.models import upload_model as sdk_upload_model
 
+import litmodels
+
 if TYPE_CHECKING:
     from lightning_sdk.models import UploadedModelInfo
 
@@ -46,6 +48,7 @@ def upload_model_files(
     progress_bar: bool = True,
     cloud_account: Optional[str] = None,
     verbose: Union[bool, int] = 1,
+    metadata: Optional[Dict[str, str]] = None,
 ) -> "UploadedModelInfo":
     """Upload a local checkpoint file to the model store.
 
@@ -57,13 +60,18 @@ def upload_model_files(
         cloud_account: The name of the cloud account to store the Model in. Only required if it can't be determined
             automatically.
         verbose: Whether to print a link to the uploaded model. If set to 0, no link will be printed.
+        metadata: Optional metadata to attach to the model. If not provided, a default metadata will be used.
 
     """
+    if not metadata:
+        metadata = {}
+    metadata.update({"litModels": litmodels.__version__})
     info = sdk_upload_model(
         name=name,
         path=path,
         progress_bar=progress_bar,
         cloud_account=cloud_account,
+        metadata=metadata,
     )
     if verbose:
         _print_model_link(name, verbose)

--- a/src/litmodels/io/gateway.py
+++ b/src/litmodels/io/gateway.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import joblib
 from lightning_utilities import module_available
@@ -24,6 +24,7 @@ def upload_model(
     cloud_account: Optional[str] = None,
     staging_dir: Optional[str] = None,
     verbose: Union[bool, int] = 1,
+    metadata: Optional[Dict[str, str]] = None,
 ) -> "UploadedModelInfo":
     """Upload a checkpoint to the model store.
 
@@ -37,6 +38,7 @@ def upload_model(
         staging_dir: A directory where the model can be saved temporarily. If not provided, a temporary directory will
             be created and used.
         verbose: Whether to print some additional information about the uploaded model.
+        metadata: Optional metadata to attach to the model. If not provided, a default metadata will be used.
 
     """
     if not staging_dir:
@@ -62,6 +64,7 @@ def upload_model(
         progress_bar=progress_bar,
         cloud_account=cloud_account,
         verbose=verbose,
+        metadata=metadata,
     )
 
 

--- a/tests/integrations/test_checkpoints.py
+++ b/tests/integrations/test_checkpoints.py
@@ -2,6 +2,7 @@ import pickle
 import re
 from unittest import mock
 
+import litmodels
 import pytest
 
 from tests.integrations import _SKIP_IF_LIGHTNING_MISSING, _SKIP_IF_PYTORCHLIGHTNING_MISSING
@@ -80,6 +81,7 @@ def test_lightning_checkpoint_callback(mock_auth, mock_upload_model, monkeypatch
         path=mock.ANY,
         progress_bar=True,
         cloud_account=None,
+        metadata={"litModels_integration": LitModelCheckpoint.__name__, "litModels": litmodels.__version__},
     )
     assert mock_upload_model.call_args_list == [expected_call] * 2
 

--- a/tests/integrations/test_duplicate.py
+++ b/tests/integrations/test_duplicate.py
@@ -1,15 +1,15 @@
 import os
+from unittest import mock
 
-import pytest
-from lightning_sdk.lightning_cloud.rest_client import GridRestClient
 from lightning_sdk.utils.resolve import _resolve_teamspace
 from litmodels.integrations.duplicate import duplicate_hf_model
 
 from tests.integrations import LIT_ORG, LIT_TEAMSPACE
 
 
-@pytest.mark.cloud()
-def test_duplicate_hf_model(tmp_path):
+@mock.patch("litmodels.integrations.duplicate.snapshot_download")
+@mock.patch("litmodels.integrations.duplicate.upload_model")
+def test_duplicate_hf_model(mock_upload_model, mock_snapshot_download, tmp_path):
     """Verify that the HF model can be duplicated to the teamspace"""
 
     # model name with random hash
@@ -17,12 +17,21 @@ def test_duplicate_hf_model(tmp_path):
     teamspace = _resolve_teamspace(org=LIT_ORG, teamspace=LIT_TEAMSPACE, user=None)
     org_team = f"{teamspace.owner.name}/{teamspace.name}"
 
-    duplicate_hf_model(hf_model="google/t5-efficient-tiny", lit_model=f"{org_team}/{model_name}")
+    hf_model = "google/t5-efficient-tiny"
+    duplicate_hf_model(hf_model=hf_model, lit_model=f"{org_team}/{model_name}", local_workdir=str(tmp_path))
 
-    client = GridRestClient()
-    model = client.models_store_get_model_by_name(
-        project_owner_name=teamspace.owner.name,
-        project_name=teamspace.name,
-        model_name=model_name,
+    mock_snapshot_download.assert_called_with(
+        repo_id=hf_model,
+        revision="main",
+        repo_type="model",
+        local_dir=tmp_path / hf_model.replace("/", "_"),
+        local_dir_use_symlinks=True,
+        ignore_patterns=[".cache*"],
+        max_workers=os.cpu_count(),
     )
-    client.models_store_delete_model(project_id=teamspace.id, model_id=model.id)
+    mock_upload_model.assert_called_with(
+        name=f"{org_team}/{model_name}",
+        model=tmp_path / hf_model.replace("/", "_"),
+        metadata={"hf_model": hf_model, "litModels_integration": "duplicate_hf_model"},
+        verbose=1,
+    )

--- a/tests/integrations/test_mixins.py
+++ b/tests/integrations/test_mixins.py
@@ -22,7 +22,9 @@ def test_pickle_push_and_pull(mock_download_model, mock_upload_model, tmp_path):
     dummy.upload_model(version="v1", temp_folder=str(tmp_path))
     # The expected registry name is "dummy_model:v1" and the file should be placed in the temp folder.
     expected_path = tmp_path / "DummyModel.pkl"
-    mock_upload_model.assert_called_once_with(name="DummyModel:v1", path=expected_path)
+    mock_upload_model.assert_called_once_with(
+        name="DummyModel:v1", path=expected_path, metadata={"litModels_integration": "PickleRegistryMixin"}
+    )
 
     # Set the mock to return the full path to the pickle file.
     mock_download_model.return_value = ["DummyModel.pkl"]
@@ -73,7 +75,9 @@ def test_pytorch_push_and_pull(mock_download_model, mock_upload_model, torch_cla
 
     dummy.upload_model(temp_folder=str(tmp_path))
     mock_upload_model.assert_called_once_with(
-        name=torch_class.__name__, path=[tmp_path / f"{torch_class.__name__}.pth", json_path]
+        name=torch_class.__name__,
+        path=[tmp_path / f"{torch_class.__name__}.pth", json_path],
+        metadata={"litModels_integration": "PyTorchRegistryMixin"},
     )
 
     # Prepare mocking for pull_from_registry.


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## Title: Enrich model upload metadata with integration details

This PR introduces support for enriching the metadata of models at the time of upload with integration-specific details such as:

- The version of the integration package used  
- The specific integration class or function involved in the upload  

### Why this is beneficial

- **Improved Traceability**: Knowing which integration and version was used makes it easier to trace issues back to specific code paths or behaviors.

- **Debugging & Support**: When issues arise, support and engineering teams can more easily reproduce and understand the context of the upload, leading to faster resolution.

- **Analytics & Insights**: Collecting integration usage data helps identify which tools are most commonly used, informing product and partnership strategies.

- **Backward Compatibility Checks**: Having version info enables better compatibility validation when models are consumed later, especially across integration boundaries.

- **Transparency**: Users and teams can see exactly how a model was registered, increasing confidence in automated pipelines.

This change lays the groundwork for future enhancements, such as UI surfacing of integration details or automated alerts when deprecated integrations are used.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
