### PR TITLE
ckpt: use checkpoint name as version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -274,7 +274,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
 
-# -- Options for todo extension ----------------------------------------------
+# -- Options for to-do extension ----------------------------------------------
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True

--- a/tests/integrations/test_checkpoints.py
+++ b/tests/integrations/test_checkpoints.py
@@ -78,14 +78,16 @@ def test_lightning_checkpoint_callback(mock_auth, mock_upload_model, monkeypatch
     trainer.fit(BoringModel())
 
     assert mock_auth.call_count == 1
-    expected_call = mock.call(
-        name=f"{expected_org}/{expected_teamspace}/{expected_model}",
-        path=mock.ANY,
-        progress_bar=True,
-        cloud_account=None,
-        metadata={"litModels_integration": LitModelCheckpoint.__name__, "litModels": litmodels.__version__},
-    )
-    assert mock_upload_model.call_args_list == [expected_call] * 2
+    assert mock_upload_model.call_args_list == [
+        mock.call(
+            name=f"{expected_org}/{expected_teamspace}/{expected_model}:{v}",
+            path=mock.ANY,
+            progress_bar=True,
+            cloud_account=None,
+            metadata={"litModels_integration": LitModelCheckpoint.__name__, "litModels": litmodels.__version__},
+        )
+        for v in ("epoch=0-step=64", "epoch=1-step=128")
+    ]
 
     # Verify paths match the expected pattern
     for call_args in mock_upload_model.call_args_list:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR updates the checkpoint versioning mechanism to use the checkpoint name instead of a monotonically increasing run index. By deriving the version identifier directly from the checkpoint name (which typically includes the model class and a timestamp), we ensure that each training run is uniquely and descriptively labeled without relying on implicit counters.

This change improves clarity, especially in collaborative environments or automated pipelines, where checkpoint names provide more meaningful context than numeric indices. It also reduces ambiguity and potential confusion when multiple runs exist, enhancing traceability and consistency in experiment tracking.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
