### PR TITLE
split `upload_model` to save & upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,17 @@ Save model:
 
 ```python
 import torch
-from litmodels import load_model, upload_model
+from litmodels import save_model
 
 model = torch.nn.Module()
-upload_model(model=model, name="your_org/your_team/torch-model")
+save_model(model=model, name="your_org/your_team/torch-model")
 ```
 
 Load model:
 
 ```python
+from litmodels import load_model
+
 model_ = load_model(name="your_org/your_team/torch-model")
 ```
 
@@ -131,7 +133,7 @@ Save model:
 ```python
 from tensorflow import keras
 
-from litmodels import upload_model
+from litmodels import save_model
 
 # Define the model
 model = keras.Sequential(
@@ -145,7 +147,7 @@ model = keras.Sequential(
 model.compile(optimizer="adam", loss="categorical_crossentropy")
 
 # Save the model
-upload_model("lightning-ai/jirka/sample-tf-keras-model", model=model)
+save_model("lightning-ai/jirka/sample-tf-keras-model", model=model)
 ```
 
 Load model:
@@ -167,7 +169,7 @@ Save model:
 
 ```python
 from sklearn import datasets, model_selection, svm
-from litmodels import upload_model
+from litmodels import save_model
 
 # Load example dataset
 iris = datasets.load_iris()
@@ -183,7 +185,7 @@ model = svm.SVC()
 model.fit(X_train, y_train)
 
 # Upload the saved model using litmodels
-upload_model(model=model, name="your_org/your_team/sklearn-svm-model")
+save_model(model=model, name="your_org/your_team/sklearn-svm-model")
 ```
 
 Use model:

--- a/examples/demo-tensorflow-keras.py
+++ b/examples/demo-tensorflow-keras.py
@@ -1,6 +1,6 @@
 from tensorflow import keras
 
-from litmodels import load_model, upload_model
+from litmodels import load_model, save_model
 
 if __name__ == "__main__":
     # Define the model
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     model.compile(optimizer="adam", loss="categorical_crossentropy")
 
     # Save the model
-    upload_model("lightning-ai/jirka/sample-tf-keras-model", model=model)
+    save_model("lightning-ai/jirka/sample-tf-keras-model", model=model)
 
     # Load the model
     model_ = load_model("lightning-ai/jirka/sample-tf-keras-model", download_dir="./my-model")

--- a/src/litmodels/__init__.py
+++ b/src/litmodels/__init__.py
@@ -7,6 +7,6 @@ from litmodels.__about__ import *  # noqa: F401, F403
 _PACKAGE_ROOT = os.path.dirname(__file__)
 _PROJECT_ROOT = os.path.dirname(_PACKAGE_ROOT)
 
-from litmodels.io import download_model, load_model, upload_model, save_model
+from litmodels.io import download_model, load_model, save_model, upload_model
 
 __all__ = ["download_model", "upload_model", "load_model", "save_model"]

--- a/src/litmodels/__init__.py
+++ b/src/litmodels/__init__.py
@@ -7,6 +7,6 @@ from litmodels.__about__ import *  # noqa: F401, F403
 _PACKAGE_ROOT = os.path.dirname(__file__)
 _PROJECT_ROOT = os.path.dirname(_PACKAGE_ROOT)
 
-from litmodels.io import download_model, load_model, upload_model
+from litmodels.io import download_model, load_model, upload_model, save_model
 
-__all__ = ["download_model", "upload_model", "load_model"]
+__all__ = ["download_model", "upload_model", "load_model", "save_model"]

--- a/src/litmodels/io/__init__.py
+++ b/src/litmodels/io/__init__.py
@@ -1,6 +1,6 @@
 """Root package for Input/output."""
 
-from litmodels.io.cloud import download_model_files, upload_model_files
+from litmodels.io.cloud import download_model_files, upload_model_files  # noqa: F401
 from litmodels.io.gateway import download_model, load_model, save_model, upload_model
 
 __all__ = ["download_model", "upload_model", "load_model", "save_model"]

--- a/src/litmodels/io/__init__.py
+++ b/src/litmodels/io/__init__.py
@@ -1,6 +1,6 @@
 """Root package for Input/output."""
 
 from litmodels.io.cloud import download_model_files, upload_model_files
-from litmodels.io.gateway import download_model, load_model, upload_model, save_model
+from litmodels.io.gateway import download_model, load_model, save_model, upload_model
 
 __all__ = ["download_model", "upload_model", "load_model", "save_model"]

--- a/src/litmodels/io/__init__.py
+++ b/src/litmodels/io/__init__.py
@@ -1,6 +1,6 @@
 """Root package for Input/output."""
 
 from litmodels.io.cloud import download_model_files, upload_model_files
-from litmodels.io.gateway import download_model, load_model, upload_model
+from litmodels.io.gateway import download_model, load_model, upload_model, save_model
 
-__all__ = ["download_model", "upload_model", "download_model_files", "upload_model_files", "load_model"]
+__all__ = ["download_model", "upload_model", "load_model", "save_model"]

--- a/tests/integrations/test_real_cloud.py
+++ b/tests/integrations/test_real_cloud.py
@@ -10,7 +10,7 @@ from lightning_sdk import Teamspace
 from lightning_sdk.lightning_cloud.rest_client import GridRestClient
 from lightning_sdk.utils.resolve import _resolve_teamspace
 
-from litmodels import download_model, load_model, upload_model
+from litmodels import download_model, load_model, save_model, upload_model
 from litmodels.integrations.duplicate import duplicate_hf_model
 from litmodels.integrations.mixins import PickleRegistryMixin, PyTorchRegistryMixin
 from litmodels.io.cloud import _list_available_teamspaces
@@ -349,7 +349,7 @@ def test_save_load_tensorflow_keras(tmp_path):
 
     # model name with random hash
     teamspace, org_team, model_name = _prepare_variables("tf-keras")
-    upload_model(f"{org_team}/{model_name}", model=model)
+    save_model(f"{org_team}/{model_name}", model=model)
 
     # Load the model
     model_ = load_model(f"{org_team}/{model_name}", download_dir=str(tmp_path))

--- a/tests/test_io_cloud.py
+++ b/tests/test_io_cloud.py
@@ -10,7 +10,7 @@ from sklearn import svm
 from torch.nn import Module
 
 import litmodels
-from litmodels import download_model, load_model, upload_model
+from litmodels import download_model, load_model, upload_model, save_model
 from litmodels.io import upload_model_files
 from litmodels.io.utils import _KERAS_AVAILABLE
 from tests.integrations import LIT_ORG, LIT_TEAMSPACE
@@ -59,7 +59,7 @@ def test_download_wrong_model_name(name, in_studio, monkeypatch):
 @pytest.mark.parametrize(
     ("model", "model_path", "verbose"),
     [
-        ("path/to/checkpoint", "path/to/checkpoint", False),
+        # ("path/to/checkpoint", "path/to/checkpoint", False),
         # (BoringModel(), "%s/BoringModel.ckpt"),
         (torch_jit.script(Module()), f"%s{os.path.sep}RecursiveScriptModule.ts", True),
         (Module(), f"%s{os.path.sep}Module.pth", True),
@@ -71,7 +71,7 @@ def test_upload_model(mock_upload_model, tmp_path, model, model_path, verbose):
     mock_upload_model.return_value.name = "org-name/teamspace/model-name"
 
     # The lit-logger function is just a wrapper around the SDK function
-    upload_model(
+    save_model(
         model=model,
         name="org-name/teamspace/model-name",
         cloud_account="cluster_id",

--- a/tests/test_io_cloud.py
+++ b/tests/test_io_cloud.py
@@ -10,7 +10,7 @@ from sklearn import svm
 from torch.nn import Module
 
 import litmodels
-from litmodels import download_model, load_model, upload_model, save_model
+from litmodels import download_model, load_model, save_model
 from litmodels.io import upload_model_files
 from litmodels.io.utils import _KERAS_AVAILABLE
 from tests.integrations import LIT_ORG, LIT_TEAMSPACE

--- a/tests/test_io_cloud.py
+++ b/tests/test_io_cloud.py
@@ -84,7 +84,7 @@ def test_upload_model(mock_upload_model, tmp_path, model, model_path, verbose):
         name="org-name/teamspace/model-name",
         cloud_account="cluster_id",
         progress_bar=True,
-        metadata={"litModels": litmodels.__version__},
+        metadata={"litModels": litmodels.__version__, "litModels_integration": "save_model"},
     )
 
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This pull request refactors the model I/O interface by **splitting the `upload_model` functionality** into two distinct methods: `save_model` and `upload_model`. The goal is to improve clarity, separate concerns, and provide better parity with the existing `download_model` / `load_model` interface.

### Changes Introduced

- **`save_model(obj)`**  
  Handles the serialization and saving of a model object to a local file or directory. This is the "magic" part that dumps an in-memory object to disk.

- **`upload_model(path)`**  
  Uploads a model **from a given path** (file or directory) to the remote storage. This is now a simple and explicit method that assumes the model has already been saved locally.

### Motivation

Previously, `upload_model` did both:
1. Serializing the model to disk
2. Uploading it to remote storage

This implicit behavior made the API less predictable and harder to pair cleanly with its counterparts (`download_model` vs `load_model`). With this change:

- `save_model` ↔ `load_model` handle local serialization/deserialization
- `upload_model` ↔ `download_model` handle remote transfers

This separation of concerns improves readability, control, and consistency across the model management workflow.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
