### PR TITLE
ci: add job to check for available secrets before integration

### DIFF
--- a/.github/workflows/ci-cloud.yml
+++ b/.github/workflows/ci-cloud.yml
@@ -12,7 +12,27 @@ defaults:
     shell: bash
 
 jobs:
+  access-secrets:
+    # try to access secrets to ensure they are available
+    # if not set job output to be false
+    runs-on: ubuntu-latest
+    outputs:
+      secrets_available: ${{ steps.check_secrets.outputs.secrets_available }}
+    steps:
+      - name: Check secrets
+        id: check_secrets
+        run: |
+          if [[ -z "${{ secrets.LIGHTNING_USER_ID }}" || -z "${{ secrets.LIGHTNING_API_KEY }}" ]]; then
+            echo "Secrets are not set. Exiting..."
+            echo "secrets_available=false" >> $GITHUB_OUTPUT
+          else
+            echo "Secrets are available."
+            echo "secrets_available=true" >> $GITHUB_OUTPUT
+          fi
+
   integration:
+    needs: access-secrets
+    if: needs.access-secrets.outputs.secrets_available == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Adds a new `access-secrets` job that verifies the presence of `LIGHTNING_USER_ID` and `LIGHTNING_API_KEY` before running integration tests, sets a `secrets_available` output flag, and conditionally skips downstream jobs when credentials are missing, preventing runtime failures and improving CI reliability.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
